### PR TITLE
add order to repository groups

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,10 +39,13 @@ build: fmtcheck
 linux: fmtcheck
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o terraform.d/plugins/linux_amd64/terraform-provider-nexus -v
 
-darwin: fmtcheck
+darwin-amd64: fmtcheck
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o terraform.d/plugins/darwin_amd64/terraform-provider-nexus -v
 
-darwin-build-install: fmtcheck
+darwin-arm64-build-install: fmtcheck
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOBUILD) -o terraform.d/plugins/darwin_arm64/terraform-provider-nexus -v
+
+darwin-amd64-build-install: fmtcheck
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o ~/.terraform.d/plugins/darwin_amd64/terraform-provider-nexus -v
 
 test: fmt

--- a/examples/test-docker/dev.tfrc
+++ b/examples/test-docker/dev.tfrc
@@ -1,0 +1,16 @@
+provider_installation {
+
+  # Use /home/developer/tmp/terraform-nexus as an overridden package directory
+  # for the datadrivers/nexus provider. This disables the version and checksum
+  # verifications for this provider and forces Terraform to look for the
+  # nexus provider plugin in the given directory.
+  # relative path also works, but no variable or ~ evaluation
+  dev_overrides {
+    "datadrivers/nexus" = "../../terraform.d/plugins/darwin_arm64/"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}

--- a/examples/test-docker/main.tf
+++ b/examples/test-docker/main.tf
@@ -1,0 +1,241 @@
+provider "nexus" {
+  insecure = true
+  password = "123123123"
+  url      = "http://127.0.0.1:8081"
+  username = "admin"
+}
+
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    nexus = {
+      source = "datadrivers/nexus"
+    }
+  }
+}
+
+resource "nexus_repository_docker_hosted" "docker-hosted-repos-rfrg" {
+  name   = "docker-h-rfrg"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+    https_port       = 5001
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}
+
+resource "nexus_repository_docker_hosted" "docker-hosted-repos-rint" {
+  name   = "docker-h-rint"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+    https_port       = 5002
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}
+
+resource "nexus_repository_docker_hosted" "docker-hosted-repos-rewt" {
+  name   = "docker-h-rewt"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+    https_port       = 5003
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}
+
+resource "nexus_repository_docker_group" "docker-group-repos" {
+  name   = "docker-g-rewt"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+  }
+  group {
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rfrg.name
+      order = "1"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rint.name
+      order = "2"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rewt.name
+      order = "3"
+    }
+
+    # member_names = [
+    #   {
+    #     name  = nexus_repository_docker_hosted.docker-hosted-repos-rewt.name,
+    #     order = "1"
+    #   },
+    #   {
+    #     name  = nexus_repository_docker_hosted.docker-hosted-repos-rint.name,
+    #     order = "2"
+    #   },
+    #   {
+    #     name  = nexus_repository_docker_hosted.docker-hosted-repos-rfrg.name,
+    #     order = "3"
+    #   },
+    # ]
+
+    # member_names = [
+    #   "docker-h-rewt",
+    #   "docker-h-rfrg",
+    #   "docker-h-rint",
+    # ]
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}
+
+resource "nexus_repository_docker_group" "docker-group-repos-1" {
+  name   = "docker-g-1"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+  }
+  group {
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rfrg.name
+      order = "1"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rint.name
+      order = "2"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rewt.name
+      order = "3"
+    }
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}
+
+resource "nexus_repository_docker_group" "docker-group-repos-2" {
+  name   = "docker-g-2"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+  }
+  group {
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rfrg.name
+      order = "1"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rint.name
+      order = "2"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rewt.name
+      order = "3"
+    }
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}
+
+resource "nexus_repository_docker_group" "docker-group-repos-3" {
+  name   = "docker-g-3"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+  }
+  group {
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rfrg.name
+      order = "1"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rint.name
+      order = "2"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rewt.name
+      order = "3"
+    }
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}
+
+resource "nexus_repository_docker_group" "docker-group-repos-4" {
+  name   = "docker-g-4"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+  }
+  group {
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rfrg.name
+      order = "1"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rint.name
+      order = "2"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rewt.name
+      order = "3"
+    }
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}
+
+resource "nexus_repository_docker_group" "docker-group-repos-5" {
+  name   = "docker-g-5"
+  online = true
+  docker {
+    force_basic_auth = false
+    v1_enabled       = false
+  }
+  group {
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rfrg.name
+      order = "1"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rint.name
+      order = "2"
+    }
+    member_names {
+      name  = nexus_repository_docker_hosted.docker-hosted-repos-rewt.name
+      order = "3"
+    }
+  }
+  storage {
+    blob_store_name                = "Default"
+    strict_content_type_validation = true
+  }
+}

--- a/internal/schema/repository/schema_group.go
+++ b/internal/schema/repository/schema_group.go
@@ -1,8 +1,6 @@
 package repository
 
 import (
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -13,14 +11,23 @@ var (
 			Schema: map[string]*schema.Schema{
 				"member_names": {
 					Description: "Member repositories names",
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"order": &schema.Schema{
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"name": &schema.Schema{
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
 					},
 					MinItems: 1,
 					Required: true,
-					Set: func(v interface{}) int {
-						return schema.HashString(strings.ToLower(v.(string)))
-					},
+					// Set: func(v interface{}) int {
+					// 	return schema.HashString(strings.ToLower(v.(string)))
+					// },
 					Type: schema.TypeSet,
 				},
 			},
@@ -35,15 +42,21 @@ var (
 			Schema: map[string]*schema.Schema{
 				"member_names": {
 					Description: "Member repositories names",
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"order": &schema.Schema{
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"name": &schema.Schema{
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
 					},
 					MinItems: 1,
 					Required: true,
-					Set: func(v interface{}) int {
-						return schema.HashString(strings.ToLower(v.(string)))
-					},
-					Type: schema.TypeSet,
+					Type:     schema.TypeSet,
 				},
 				"writable_member": {
 					Description: "Pro-only: This field is for the Group Deployment feature available in NXRM Pro.",
@@ -62,8 +75,17 @@ var (
 			Schema: map[string]*schema.Schema{
 				"member_names": {
 					Description: "Member repositories names",
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"order": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
 					},
 					Computed: true,
 					Type:     schema.TypeSet,
@@ -79,8 +101,17 @@ var (
 			Schema: map[string]*schema.Schema{
 				"member_names": {
 					Description: "Member repositories names",
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"order": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
 					},
 					Computed: true,
 					Type:     schema.TypeSet,

--- a/internal/services/repository/flatten.go
+++ b/internal/services/repository/flatten.go
@@ -57,20 +57,39 @@ func flattenComponent(component *repository.Component) []map[string]interface{} 
 }
 
 func flattenGroup(group *repository.Group) []map[string]interface{} {
-	return []map[string]interface{}{
-		{
-			"member_names": tools.StringSliceToInterfaceSlice(group.MemberNames),
-		},
+	data := map[string]interface{}{}
+
+	ois := make([]interface{}, len(group.MemberNames))
+
+	for i, memberName := range group.MemberNames {
+		oi := make(map[string]interface{})
+
+		oi["name"] = memberName
+		// array index to human-friendly order
+		oi["order"] = i + 1
+		ois[i] = oi
 	}
+
+	return []map[string]interface{}{data}
 }
 
 func flattenGroupDeploy(group *repository.GroupDeploy) []map[string]interface{} {
-	data := map[string]interface{}{
-		"member_names": tools.StringSliceToInterfaceSlice(group.MemberNames),
+	data := map[string]interface{}{}
+
+	ois := make([]interface{}, len(group.MemberNames))
+
+	for i, memberName := range group.MemberNames {
+		oi := make(map[string]interface{})
+
+		oi["name"] = memberName
+		// array index to human-friendly order
+		oi["order"] = i + 1
+		ois[i] = oi
 	}
 	if group.WritableMember != nil {
 		data["writable_member"] = *group.WritableMember
 	}
+	data["member_names"] = ois
 	return []map[string]interface{}{data}
 }
 

--- a/internal/services/repository/resource_repository_bower_group.go
+++ b/internal/services/repository/resource_repository_bower_group.go
@@ -5,6 +5,7 @@ import (
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
 	"github.com/datadrivers/terraform-provider-nexus/internal/schema/common"
 	repositorySchema "github.com/datadrivers/terraform-provider-nexus/internal/schema/repository"
+	"github.com/datadrivers/terraform-provider-nexus/internal/tools"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,8 +38,10 @@ func getBowerGroupRepositoryFromResourceData(resourceData *schema.ResourceData) 
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.BowerGroupRepository{

--- a/internal/services/repository/resource_repository_docker_group.go
+++ b/internal/services/repository/resource_repository_docker_group.go
@@ -41,10 +41,11 @@ func getDockerGroupRepositoryFromResourceData(resourceData *schema.ResourceData)
 	dockerConfig := resourceData.Get("docker").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
-
 	repo := repository.DockerGroupRepository{
 		Name:   resourceData.Get("name").(string),
 		Online: resourceData.Get("online").(bool),
@@ -92,7 +93,6 @@ func setDockerGroupRepositoryToResourceData(repo *repository.DockerGroupReposito
 	if err := resourceData.Set("storage", flattenStorage(&repo.Storage)); err != nil {
 		return err
 	}
-
 	if err := resourceData.Set("group", flattenGroupDeploy(&repo.Group)); err != nil {
 		return err
 	}
@@ -125,7 +125,6 @@ func resourceDockerGroupRepositoryRead(resourceData *schema.ResourceData, m inte
 		resourceData.SetId("")
 		return nil
 	}
-
 	return setDockerGroupRepositoryToResourceData(repo, resourceData)
 }
 

--- a/internal/services/repository/resource_repository_go_group.go
+++ b/internal/services/repository/resource_repository_go_group.go
@@ -5,6 +5,7 @@ import (
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
 	"github.com/datadrivers/terraform-provider-nexus/internal/schema/common"
 	repositorySchema "github.com/datadrivers/terraform-provider-nexus/internal/schema/repository"
+	"github.com/datadrivers/terraform-provider-nexus/internal/tools"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,8 +38,10 @@ func getGoGroupRepositoryFromResourceData(resourceData *schema.ResourceData) rep
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.GoGroupRepository{

--- a/internal/services/repository/resource_repository_maven_group.go
+++ b/internal/services/repository/resource_repository_maven_group.go
@@ -5,6 +5,7 @@ import (
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
 	"github.com/datadrivers/terraform-provider-nexus/internal/schema/common"
 	repositorySchema "github.com/datadrivers/terraform-provider-nexus/internal/schema/repository"
+	"github.com/datadrivers/terraform-provider-nexus/internal/tools"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,8 +38,10 @@ func getMavenGroupRepositoryFromResourceData(resourceData *schema.ResourceData) 
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.MavenGroupRepository{

--- a/internal/services/repository/resource_repository_npm_group.go
+++ b/internal/services/repository/resource_repository_npm_group.go
@@ -38,10 +38,11 @@ func getNpmGroupRepositoryFromResourceData(resourceData *schema.ResourceData) re
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
-
 	repo := repository.NpmGroupRepository{
 		Name:   resourceData.Get("name").(string),
 		Online: resourceData.Get("online").(bool),

--- a/internal/services/repository/resource_repository_nuget_group.go
+++ b/internal/services/repository/resource_repository_nuget_group.go
@@ -5,6 +5,7 @@ import (
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
 	"github.com/datadrivers/terraform-provider-nexus/internal/schema/common"
 	repositorySchema "github.com/datadrivers/terraform-provider-nexus/internal/schema/repository"
+	"github.com/datadrivers/terraform-provider-nexus/internal/tools"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,8 +38,10 @@ func getNugetGroupRepositoryFromResourceData(resourceData *schema.ResourceData) 
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.NugetGroupRepository{

--- a/internal/services/repository/resource_repository_pypi_group.go
+++ b/internal/services/repository/resource_repository_pypi_group.go
@@ -5,6 +5,7 @@ import (
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
 	"github.com/datadrivers/terraform-provider-nexus/internal/schema/common"
 	repositorySchema "github.com/datadrivers/terraform-provider-nexus/internal/schema/repository"
+	"github.com/datadrivers/terraform-provider-nexus/internal/tools"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,8 +38,10 @@ func getPypiGroupRepositoryFromResourceData(resourceData *schema.ResourceData) r
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.PypiGroupRepository{

--- a/internal/services/repository/resource_repository_r_group.go
+++ b/internal/services/repository/resource_repository_r_group.go
@@ -5,6 +5,7 @@ import (
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
 	"github.com/datadrivers/terraform-provider-nexus/internal/schema/common"
 	repositorySchema "github.com/datadrivers/terraform-provider-nexus/internal/schema/repository"
+	"github.com/datadrivers/terraform-provider-nexus/internal/tools"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,8 +38,10 @@ func getRGroupRepositoryFromResourceData(resourceData *schema.ResourceData) repo
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.RGroupRepository{

--- a/internal/services/repository/resource_repository_raw_group.go
+++ b/internal/services/repository/resource_repository_raw_group.go
@@ -5,6 +5,7 @@ import (
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
 	"github.com/datadrivers/terraform-provider-nexus/internal/schema/common"
 	repositorySchema "github.com/datadrivers/terraform-provider-nexus/internal/schema/repository"
+	"github.com/datadrivers/terraform-provider-nexus/internal/tools"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,8 +38,10 @@ func getRawGroupRepositoryFromResourceData(resourceData *schema.ResourceData) re
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.RawGroupRepository{

--- a/internal/services/repository/resource_repository_rubygems_group.go
+++ b/internal/services/repository/resource_repository_rubygems_group.go
@@ -5,6 +5,7 @@ import (
 	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
 	"github.com/datadrivers/terraform-provider-nexus/internal/schema/common"
 	repositorySchema "github.com/datadrivers/terraform-provider-nexus/internal/schema/repository"
+	"github.com/datadrivers/terraform-provider-nexus/internal/tools"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,8 +38,10 @@ func getRubygemsGroupRepositoryFromResourceData(resourceData *schema.ResourceDat
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.RubyGemsGroupRepository{

--- a/internal/services/repository/resource_repository_yum_group.go
+++ b/internal/services/repository/resource_repository_yum_group.go
@@ -40,8 +40,10 @@ func getYumGroupRepositoryFromResourceData(resourceData *schema.ResourceData) re
 	storageConfig := resourceData.Get("storage").([]interface{})[0].(map[string]interface{})
 	groupConfig := resourceData.Get("group").([]interface{})[0].(map[string]interface{})
 	groupMemberNames := []string{}
-	for _, name := range groupConfig["member_names"].(*schema.Set).List() {
-		groupMemberNames = append(groupMemberNames, name.(string))
+	l := groupConfig["member_names"].(*schema.Set).List()
+	tools.SortSliceByKey(l, tools.SortKey)
+	for _, member := range l {
+		groupMemberNames = append(groupMemberNames, member.(map[string]interface{})["name"].(string))
 	}
 
 	repo := repository.YumGroupRepository{

--- a/internal/tools/main.go
+++ b/internal/tools/main.go
@@ -68,3 +68,13 @@ func ConvertStringSet(set *schema.Set) []string {
 
 	return s
 }
+
+const (
+	SortKey = "order"
+)
+
+func SortSliceByKey(s []interface{}, key string) {
+	sort.Slice(s, func(i, j int) bool {
+		return s[i].(map[string]interface{})[key].(int) < s[j].(map[string]interface{})[key].(int)
+	})
+}

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nexus-oss:
-    image: "sonatype/nexus3:${NEXUS_VERSION}"
+    image: "klo2k/nexus3"
     ports:
       - "${NEXUS_PORT}:8081"
     volumes:


### PR DESCRIPTION
Order of member in group are not respected when we create repository groups, as shown in:

- https://github.com/datadrivers/terraform-provider-nexus/issues/339
- https://github.com/datadrivers/terraform-provider-nexus/issues/25
- https://github.com/datadrivers/terraform-provider-nexus/issues/140.
This PR fix it by convert group's `members_names` from
```
DataSourceGroupDeploy = &schema.Schema{
		Description: "Configuration for repository group",
		Elem: &schema.Resource{
			Schema: map[string]*schema.Schema{
				"member_names": {
					Description: "Member repositories names",
					Elem: &schema.Resource{
						Schema: map[string]*schema.Schema{
							"order": {
								Type:     schema.TypeInt,
								Required: true,
							},
							"name": {
								Type:     schema.TypeString,
								Required: true,
							},
						},
					},
					Computed: true,
					Type:     schema.TypeSet,
				},
				"writable_member": {
					Description: "Pro-only: This field is for the Group Deployment feature available in NXRM Pro.",
					Computed:    true,
					Type:        schema.TypeString,
				},
			},
		},
		Computed: true,
		Type:     schema.TypeList,
	}
```
to 
```	
DataSourceGroupDeploy = &schema.Schema{
		Description: "Configuration for repository group",
		Elem: &schema.Resource{
			Schema: map[string]*schema.Schema{
				"member_names": {
					Description: "Member repositories names",
					Elem: &schema.Schema{
						Type: schema.TypeString,
					},
					Computed: true,
					Type:     schema.TypeSet,
				},
				"writable_member": {
					Description: "Pro-only: This field is for the Group Deployment feature available in NXRM Pro.",
					Computed:    true,
					Type:        schema.TypeString,
				},
			},
		},
		Computed: true,
		Type:     schema.TypeList,
	}
``` 